### PR TITLE
Line 224: deleted the comma behind "duration: duration" because of error 

### DIFF
--- a/js/pluit-carousel.js
+++ b/js/pluit-carousel.js
@@ -221,7 +221,7 @@ Pluit.Carousel.Element = Class.create({
             afterFinish: function() {
               this.onTheMove = false;
               new Effect.Appear(this.elSlidesPanel, {
-                duration: duration,
+                duration: duration
               });
             }.bind(this)
           }); 


### PR DESCRIPTION
Line 224: deleted the comma behind "duration: duration" because of error in IE7
